### PR TITLE
Updated Oauth Ban verbiage

### DIFF
--- a/CloudAppSecurityDocs/app-permission-policy.md
+++ b/CloudAppSecurityDocs/app-permission-policy.md
@@ -10,7 +10,7 @@ ms.topic: how-to
 
 In addition to the [existing investigation of OAuth apps](manage-app-permissions.md) connected to your environment, you can set permission policies so that you get automated notifications when an OAuth app meets certain criteria. For example, you can automatically be alerted when there are apps that require a high permission level and were authorized by more than 50 users.
 
-OAuth app policies enable you to investigate which permissions each app requested and which users authorized them for Office 365, Google Workspace, and Salesforce. You're also able to mark these permissions as approved or banned. Marking them as banned will revoke permissions for each app for each user who authorized it.
+OAuth app policies enable you to investigate which permissions each app requested and which users authorized them for Office 365, Google Workspace, and Salesforce. You're also able to mark these permissions as approved or banned. Marking them as banned will disable the correlating Enteprise Application.
 
 ## Create a new OAuth app policy
 


### PR DESCRIPTION
Original verbiage indicated the consent and or API permissions would be revoked\removed. Testing indicates that is not the case and the enterprise application is just switched to disabled.