### PR TITLE
Update connect-workday.md with GCC URI

### DIFF
--- a/CloudAppSecurityDocs/connect-workday.md
+++ b/CloudAppSecurityDocs/connect-workday.md
@@ -60,7 +60,7 @@ For more information about setting up Workday integration users, security groups
     | Client Name | Microsoft Defender for Cloud Apps |
     | Client Grant Type | Authorization Code Grant |
     | Access Token Type | Bearer |
-    | Redirection URI | `https://portal.cloudappsecurity.com/api/oauth/connect`<br /><br />**Note**: For US Government GCC High customers, enter the following value: `https://portal.cloudappsecurity.us/api/oauth/connect` |
+    | Redirection URI | `https://portal.cloudappsecurity.com/api/oauth/connect`<br /><br /> **Note**: For US Government GCC customers, enter the following value:            `https://portal.cloudappsecuritygov.com/api/oauth/connect`<br />  For US Government GCC High customers, enter the following value: `https://portal.cloudappsecurity.us/api/oauth/connect` |
     | Non-Expiring Refresh Tokens | Yes |
     | Scope (Functional Areas) | **Staffing** and **System** |
 


### PR DESCRIPTION
Document is missing details for "Redirection URI" for GCC customers, hence GCC customers are getting confused and try to use the commercial or GCC High URI that is provided in the document. Adding the URI for GCC customers will help them use the correct URI for GCC and reduce support cases for CSS. 

Currently, doc only shares the URI for Commercial and GCC High Customers, URI details for GCC customers is missing. So I added the URI details for GCC as well.

Line added to the doc:  For US Government GCC customers, enter the following value: `https://portal.cloudappsecuritygov.com/api/oauth/connect`