### PR TITLE
Update azip-integration.md

### DIFF
--- a/CloudAppSecurityDocs/azip-integration.md
+++ b/CloudAppSecurityDocs/azip-integration.md
@@ -61,7 +61,6 @@ Note the following limits when using Microsoft Purview labels with Defender for 
 | Limit | Description |
 |------|--------------|
 | **Files with labels or protection applied outside of Defender for Cloud Apps** | 	Unprotected labels applied outside of Defender for Cloud Apps can be overridden by Defender for Cloud Apps but can’t be removed.  <br><br>Defender for Cloud Apps cannot remove labels with protection from files that were labeled outside of Defender for Cloud Apps. <br><br>To scan files with protection applied outside of Defender for Cloud apps, [grant permissions to inspect content for protected files](content-inspection.md#content-inspection-for-protected-files).|
-| **Files labeled by Defender for Cloud Apps** | Defender for Cloud Apps cannot override labels on files that have already been labeled by Defender for Cloud Apps.|
 | **Password protected files** |Defender for Cloud Apps cannot read labels on password-protected files. |
 | **Empty files**	| Empty files are not labeled by Defender for Cloud Apps |
 | **Libraries that require checkout** |	Defender for Cloud Apps cannot labels files located in libraries that are [configured to require checkout](https://support.microsoft.com/office/set-up-a-library-to-require-check-out-of-files-0c73792b-f727-4e19-a1f9-3173899e695b). |


### PR DESCRIPTION
removed this row

| **Files labeled by Defender for Cloud Apps** | Defender for Cloud Apps cannot override labels on files that have already been labeled by Defender for Cloud Apps.|