### PR TITLE
Update api-alerts-close-false-positive.md

### DIFF
--- a/CloudAppSecurityDocs/api-alerts-close-false-positive.md
+++ b/CloudAppSecurityDocs/api-alerts-close-false-positive.md
@@ -35,7 +35,7 @@ POST /api/v1/alerts/close_false_positive/
 Here is an example of the request.
 
 ```rest
-curl -XPOST -H "Authorization:Token <your_token_key>" -H "Content-Type: application/json" "https://<tenant_id>.<tenant_region>.contoso.com/api/v1/alerts/close_false_positive/" -d '{
+curl -XPOST -H "Authorization:Token <your_token_key>" -H "Content-Type: application/json" "https://<tenant_id>.<tenant_region>.portal.cloudappsecurity.com/api/v1/alerts/close_false_positive/" -d '{
   "filters": {
     "id": {
       "eq": [


### PR DESCRIPTION
portal.cloudappsecurity.com is the correct domain. Contoso.com is not, however it is mentioned in a few docs.