### PR TITLE
Update api-alerts-fetch.md

### DIFF
--- a/CloudAppSecurityDocs/api-alerts-fetch.md
+++ b/CloudAppSecurityDocs/api-alerts-fetch.md
@@ -29,7 +29,7 @@ GET /api/v1/alerts/<pk>/
 Here is an example of the request.
 
 ```rest
-curl -XGET -H "Authorization:Token <your_token_key>" "https://<tenant_id>.<tenant_region>.contoso.com/api/v1/alerts/<pk>/"
+curl -XGET -H "Authorization:Token <your_token_key>" "https://<tenant_id>.<tenant_region>.portal.cloudappsecurity.com/api/v1/alerts/<pk>/"
 ```
 
 ### Response


### PR DESCRIPTION
portal.cloudappsecurity.com is the correct domain. Contoso.com is not, however it is mentioned in a few docs.