### PR TITLE
Update api-alerts-mark-read.md

### DIFF
--- a/CloudAppSecurityDocs/api-alerts-mark-read.md
+++ b/CloudAppSecurityDocs/api-alerts-mark-read.md
@@ -29,7 +29,7 @@ POST /api/v1/alerts/<pk>/read/
 Here is an example of the request.
 
 ```rest
-curl -XPOST -H "Authorization:Token <your_token_key>" -H "Content-Type: application/json" "https://<tenant_id>.<tenant_region>.contoso.com/api/v1/alerts/<pk>/read/"
+curl -XPOST -H "Authorization:Token <your_token_key>" -H "Content-Type: application/json" "https://<tenant_id>.<tenant_region>.portal.cloudappsecurity.com/api/v1/alerts/<pk>/read/"
 ```
 
 [!INCLUDE [Open support ticket](includes/support.md)]


### PR DESCRIPTION
portal.cloudappsecurity.com is the correct domain. Contoso.com is not, however it is mentioned in a few docs.