### PR TITLE
Update api-discovery-list-streams.md

### DIFF
--- a/CloudAppSecurityDocs/api-discovery-list-streams.md
+++ b/CloudAppSecurityDocs/api-discovery-list-streams.md
@@ -23,7 +23,7 @@ GET api/discovery/streams/
 Here is an example of the request.
 
 ```rest
-curl -XGET -H "Authorization:Token <your_token_key>" "https://<tenant_id>.<tenant_region>.contoso.com/api/discovery/streams/"
+curl -XGET -H "Authorization:Token <your_token_key>" "https://<tenant_id>.<tenant_region>.portal.cloudappsecurity.com/api/discovery/streams/"
 ```
 
 ### Response


### PR DESCRIPTION
portal.cloudappsecurity.com is the correct domain. Contoso.com is not, however it is mentioned in a few docs.